### PR TITLE
Bump image version, fix default-mysql-client install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM php:7.2.7-apache
+FROM php:7.4-apache
 RUN apt update; \
     apt upgrade; \
-    apt-get install -y  mysql-client;
+    apt-get install -y default-mysql-client;
 RUN docker-php-ext-install mysqli
 COPY ./lwt_html /var/www/html
 ## COPY ./php.ini /usr/local/etc/php


### PR DESCRIPTION
When trying to build the current Dockerfile, the mysql-client installation step was failing. I managed to fix that by changing the package to default-mysql-client, and I also bumped the image version to PHP 7.4 which uses a newer version of Debian (Debian 11 vs Debian 9). The app seems to be working after some light testing, however I have not thoroughly tested to make sure the newer PHP version doesn't introduce any bugs.